### PR TITLE
Hotfix for teleporting infinite loop

### DIFF
--- a/NewVersion/include/ebotai/check.inc
+++ b/NewVersion/include/ebotai/check.inc
@@ -161,7 +161,7 @@ public void CheckSlowThink(const int client)
 			}
 		}
 		
-		if (!m_hasEnemiesNear[client] && m_class[client] == TFClass_Engineer && m_meleeID[client] == 589)
+		if (m_hasEnemiesNear[client] && m_class[client] == TFClass_Engineer && m_meleeID[client] == 589)
 		{
 			if (GetClientHealth(client) < (GetMaxHealth(client) / 1.4))
 			{

--- a/NewVersion/include/ebotai/check.inc
+++ b/NewVersion/include/ebotai/check.inc
@@ -166,7 +166,7 @@ public void CheckSlowThink(const int client)
 			if (GetClientHealth(client) < (GetMaxHealth(client) / 1.3))
 			{
 				EquipWeaponSlot(client, 2);
-				if (IsWeaponSlotActive(client, 2) && (GetClientHealth(client) < (GetMaxHealth(client) / 1.4)))
+				if (IsWeaponSlotActive(client, 2) && (GetClientHealth(client) < (GetMaxHealth(client) / 1.3)))
 					FakeClientCommand(client, "eureka_teleport 0");
 			}
 		}

--- a/NewVersion/include/ebotai/check.inc
+++ b/NewVersion/include/ebotai/check.inc
@@ -163,7 +163,7 @@ public void CheckSlowThink(const int client)
 		
 		if (m_hasEnemiesNear[client] && m_class[client] == TFClass_Engineer && m_meleeID[client] == 589)
 		{
-			if (GetClientHealth(client) < (GetMaxHealth(client) / 1.4))
+			if (GetClientHealth(client) < (GetMaxHealth(client) / 1.5))
 			{
 				EquipWeaponSlot(client, 2);
 				if (IsWeaponSlotActive(client, 2) && (GetClientHealth(client) < (GetMaxHealth(client) / 1.4)))

--- a/NewVersion/include/ebotai/check.inc
+++ b/NewVersion/include/ebotai/check.inc
@@ -163,7 +163,7 @@ public void CheckSlowThink(const int client)
 		
 		if (m_hasEnemiesNear[client] && m_class[client] == TFClass_Engineer && m_meleeID[client] == 589)
 		{
-			if (GetClientHealth(client) < (GetMaxHealth(client) / 1.5))
+			if (GetClientHealth(client) < (GetMaxHealth(client) / 1.3))
 			{
 				EquipWeaponSlot(client, 2);
 				if (IsWeaponSlotActive(client, 2) && (GetClientHealth(client) < (GetMaxHealth(client) / 1.4)))


### PR DESCRIPTION
Changed from not enemies around to enemies around so they don't get stuck in spawn by constant teleporting. Found this well testing.